### PR TITLE
Add: add search forms in others sales/purchases pages

### DIFF
--- a/app/Http/Controllers/PurchaseOrdersController.php
+++ b/app/Http/Controllers/PurchaseOrdersController.php
@@ -106,6 +106,8 @@ class PurchaseOrdersController extends Controller
 
     public function othersPurchases() 
     {
+        $isSalesPage = false;
+
         $user = Auth::user();
 
         $othersPurchases = PurchaseOrder::where('user_id', '!=', Auth::id())->orderBy('created_at', 'desc')->paginate(10);
@@ -113,6 +115,25 @@ class PurchaseOrdersController extends Controller
         return view('purchase.others_purchases', [
             'user' => $user,
             'othersPurchases' => $othersPurchases,
+            'isSalesPage' => $isSalesPage,
+        ]);
+    }
+
+    // 提案をキーワードで検索
+    public function search(Request $request)
+    {
+        $isSalesPage = false;
+
+        $user = Auth::user();
+
+        $keyword = request('keyword');
+
+        $othersPurchases = PurchaseOrder::where('user_id', '!=', Auth::id())->where('title', 'like', "%{$keyword}%")->orderBy('created_at', 'desc')->paginate(10);
+
+        return view('purchase.others_purchases', [
+            'user' => $user,
+            'othersPurchases' => $othersPurchases,
+            'isSalesPage' => $isSalesPage,
         ]);
     }
 }

--- a/app/Http/Controllers/SalesOrdersController.php
+++ b/app/Http/Controllers/SalesOrdersController.php
@@ -86,6 +86,8 @@ class SalesOrdersController extends Controller
     // 自分以外の全ユーザの依頼を表示。
     public function othersSales()
     {
+        $isSalesPage = true;
+
         $user = Auth::user();
 
         $othersSales = SalesOrder::where('user_id', '!=', Auth::id())->orderBy('created_at', 'desc')->paginate(10);
@@ -93,6 +95,25 @@ class SalesOrdersController extends Controller
         return view('sales.others_sales', [
             'user' => $user,
             'othersSales' => $othersSales,
+            'isSalesPage' => $isSalesPage,
+        ]);
+    }
+
+    // 依頼をキーワードで検索
+    public function search(Request $request)
+    {
+        $isSalesPage = true;
+
+        $user = Auth::user();
+
+        $keyword = request('keyword');
+
+        $othersSales = SalesOrder::where('user_id', '!=', Auth::id())->where('title', 'like', "%{$keyword}%")->orderBy('created_at', 'desc')->paginate(10);
+
+        return view('sales.others_sales', [
+            'user' => $user,
+            'othersSales' => $othersSales,
+            'isSalesPage' => $isSalesPage,
         ]);
     }
 }

--- a/resources/views/commons/search_form.blade.php
+++ b/resources/views/commons/search_form.blade.php
@@ -1,0 +1,8 @@
+<div>
+    <form action="{{ $isSalesPage ? route('sales-search') : route('purchases-search')}}" method="GET" class="flex">
+        <input type="text" name="keyword" placeholder="キーワードで依頼を検索…" class="shadow appearance-none border rounded w-full py-1 px-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline mr-2">    
+        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded focus:outline-none focus:shadow-outline">検索</button>
+    </form>
+</div>
+
+{{-- 将来的にこの検索フォームで自分の依頼/提案、他人の依頼/提案を検索できるよう、条件で分岐させる --}}

--- a/resources/views/purchase/others_purchases.blade.php
+++ b/resources/views/purchase/others_purchases.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     @if (Auth::id() == $user->id)
         @if (isset($othersPurchases))
+
+            @include('commons.search_form')
+
             <div class="sm:grid sm:grid-cols-3 sm:gap-10">
                 @foreach ($othersPurchases as $othersPurchase)
                     <aside class="mt-4">

--- a/resources/views/sales/others_sales.blade.php
+++ b/resources/views/sales/others_sales.blade.php
@@ -3,6 +3,9 @@
 @section('content')
     @if (Auth::id() == $user->id)
         @if (isset($othersSales))
+
+            @include('commons.search_form')
+
             <div class="sm:grid sm:grid-cols-3 sm:gap-10">
                 @foreach ($othersSales as $othersSale)
                     <aside class="mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ Route::group(['middleware' => ['auth']], function() {
     Route::delete('sales/destroy/{saleId}', [SalesOrdersController::class, 'destroy'])->name('sales-destroy');
     // 「依頼を探す」ページ
     Route::get('others/sales/index', [SalesOrdersController::class, 'othersSales'])->name('others-sales');
+    Route::get('others/sales/search', [SalesOrdersController::class, 'search'])->name('sales-search');
 });
 
 // 提案に関するページ
@@ -66,6 +67,7 @@ Route::group(['middleware' => ['auth']], function() {
     Route::delete('purchase/destroy/{purchaseId}', [PurchaseOrdersController::class, 'destroy'])->name('purchase-destroy');
     // 「提案を探す」ページ
     Route::get('others/purchases/index', [PurchaseOrdersController::class, 'othersPurchases'])->name('others-purchases');
+    Route::get('others/purchases/search', [PurchaseOrdersController::class, 'search'])->name('purchases-search');
 });
 
 // 「プロフィール」ページ


### PR DESCRIPTION
- [ ] 「依頼を探す」ページに検索機能を実装
- [ ] 「提案を探す」ページに検索機能を実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented new search capabilities for both sales and purchase orders, allowing users to filter based on keywords.
	- Introduced a dynamic search form in the UI that adapts to sales or purchase searches.

- **Enhancements**
	- Added visual components to sales and purchase views to include the new search form.

- **Routing**
	- Established new routes for the search functionality in sales and purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->